### PR TITLE
Update packages to support PureScript v0.10.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-pux-spectacle",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -13,10 +13,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-pux": "^5.0.3"
+    "purescript-console": "^2.0.0",
+    "purescript-pux": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^1.0.0"
+    "purescript-psci-support": "^2.0.0"
   }
 }

--- a/src/Spectacle/Attributes.purs
+++ b/src/Spectacle/Attributes.purs
@@ -1,8 +1,9 @@
 module Spectacle.Attributes where
 
 import Data.Foreign (Foreign)
-import Data.Time.Duration (unMilliseconds, Milliseconds)
-import Prelude (map, (<<<), (=<<), ($))
+import Data.Newtype (unwrap)
+import Data.Time.Duration (Milliseconds)
+import Prelude (map, (<<<))
 import Pux.Html (Attribute)
 import Pux.Html.Attributes (attr)
 
@@ -57,7 +58,7 @@ transition = attr "transition" <<< map toString
     toString Spin = "spin"
 
 transitionDuration :: forall a. Milliseconds -> Attribute a
-transitionDuration = attr "transitionDuration" <<< unMilliseconds
+transitionDuration = attr "transitionDuration" <<< unwrap
 
 showControls :: forall a. Attribute a
 showControls = attr "controls" true


### PR DESCRIPTION
I updated the package dependencies and changed `unMilliseconds` to `unwrap` in `Spectacle.Attributes` as to support the latest version of the compiler and the latest package sets.